### PR TITLE
add feature to compile on stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,15 @@ license = "MIT"
 
 keywords = ["os", "malloc", "slab", "alloc", "memory"]
 
+[features]
+unstable = [ "spin/unstable" ]
+default = [ "unstable" ]
+
 [dependencies]
-spin = "0.4.8"
+spin = { version = "0.4.8", default_features = false }
 log = "0.4"
 
 [dev-dependencies]
 rand = "0.3"
 libc = "0.2"
 env_logger = "0.5.10"
-


### PR DESCRIPTION
Hi, I added a feature so that it is possible to use the crate with stable Rust (by using --no-default-features).
I don't know, whether there is a way to get around the code duplication, which I introduced, but spin-rs uses a similar pattern for const functions (see e.g. https://github.com/mvdnes/spin-rs/blob/b03c4781698e0404297b91c2ff2f1f6857ef3b47/src/mutex.rs#L134).
If you have any feedback, I will gladly incorporate it into the PR.