### PR TITLE
adding features to select page and cacheline sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,13 @@ keywords = ["os", "malloc", "slab", "alloc", "memory"]
 
 [features]
 unstable = []
-default = [ "unstable" ]
+default = [ "unstable", "cacheline_64", "aarch64_granule_4k" ]
+cacheline_32 = []
+cacheline_64 = []
+cacheline_128 = []
+aarch64_granule_4k = []
+aarch64_granule_16k = []
+aarch64_granule_64k = []
 
 [dependencies]
 log = "0.4"

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -1,0 +1,77 @@
+// configuration options for the aarch64 architecture
+
+#[cfg(all(feature = "cacheline_32", feature = "cacheline_64"))]
+compile_error!(
+    "feature \"cacheline_32\" and feature \"cacheline_64\" cannot be enabled at the same time"
+);
+
+#[cfg(all(feature = "cacheline_32", feature = "cacheline_128"))]
+compile_error!(
+    "feature \"cacheline_32\" and feature \"cacheline_128\" cannot be enabled at the same time"
+);
+
+#[cfg(all(feature = "cacheline_64", feature = "cacheline_128"))]
+compile_error!(
+    "feature \"cacheline_64\" and feature \"cacheline_128\" cannot be enabled at the same time"
+);
+
+#[cfg(not(any(
+    feature = "cacheline_32",
+    feature = "cacheline_64",
+    feature = "cacheline_128"
+)))]
+compile_error!("need to select a cacheline size using features.");
+
+#[cfg(feature = "cacheline_32")]
+pub const CACHE_LINE_SIZE: usize = 32;
+
+#[cfg(feature = "cacheline_64")]
+pub const CACHE_LINE_SIZE: usize = 64;
+
+#[cfg(feature = "cacheline_128")]
+pub const CACHE_LINE_SIZE: usize = 128;
+
+#[cfg(all(feature = "aarch64_granule_4k", feature = "aarch64_granule_16k"))]
+compile_error!(
+    "feature \"aarch64_granule_4k\" and feature \"aarch64_granule_16k\" cannot be enabled at the same time"
+);
+
+#[cfg(all(feature = "aarch64_granule_4k", feature = "aarch64_granule_64k"))]
+compile_error!(
+    "feature \"aarch64_granule_4k\" and feature \"aarch64_granule_64k\" cannot be enabled at the same time"
+);
+
+#[cfg(all(feature = "aarch64_granule_16k", feature = "aarch64_granule_64k"))]
+compile_error!(
+    "feature \"aarch64_granule_16k\" and feature \"aarch64_granule_64k\" cannot be enabled at the same time"
+);
+
+#[cfg(not(any(
+    feature = "aarch64_granule_4k",
+    feature = "aarch64_granule_16k",
+    feature = "aarch64_granule_64k"
+)))]
+compile_error!("need to select a granule size using features.");
+
+#[cfg(feature = "aarch64_granule_4k")]
+pub const BASE_PAGE_SIZE: usize = 4 * 1024;
+
+#[cfg(feature = "aarch64_granule_4k")]
+#[allow(unused)]
+pub const LARGE_PAGE_SIZE: usize = 2 * 1024 * 1024;
+
+#[cfg(feature = "aarch64_granule_16k")]
+pub const BASE_PAGE_SIZE: usize = 16 * 1024;
+
+#[cfg(feature = "aarch64_granule_16k")]
+#[allow(unused)]
+pub const LARGE_PAGE_SIZE: usize = 32 * 1024 * 1024;
+
+#[cfg(feature = "aarch64_granule_64k")]
+pub const BASE_PAGE_SIZE: usize = 64 * 1024;
+
+#[cfg(feature = "aarch64_granule_64k")]
+#[allow(unused)]
+pub const LARGE_PAGE_SIZE: usize = 512 * 1024 * 1024;
+
+pub type VAddr = usize;

--- a/src/arch/x86/mod.rs
+++ b/src/arch/x86/mod.rs
@@ -1,0 +1,22 @@
+// configuration options for the x86 architecture
+
+#[cfg(feature = "cacheline_32")]
+compile_error!("enabling 32-byte cacheline size on x86 is not supported.");
+
+#[cfg(feature = "cacheline_128")]
+compile_error!("enabling 128-byte cacheline size on x86 is not supported.");
+
+#[cfg(all(target_arch = "x86_64", feature = "largepage_4M"))]
+compile_error!("enabling 4 MiB large page size on x86 is not supported.");
+
+#[cfg(target_arch = "x86_64")]
+pub const LARGE_PAGE_SIZE: usize = 2 * 1024 * 1024;
+
+#[cfg(target_arch = "x86_32")]
+pub const LARGE_PAGE_SIZE: usize = 4 * 1024 * 1024;
+
+pub const CACHE_LINE_SIZE: usize = 64;
+
+pub const BASE_PAGE_SIZE: usize = 4 * 1024;
+
+pub type VAddr = usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,21 @@
 #![crate_name = "slabmalloc"]
 #![crate_type = "lib"]
 
+// The x86-64 platform specific code.
+#[cfg(all(target_arch = "x86_64"))]
+#[path = "arch/x86/mod.rs"]
+pub mod arch;
+
+// The aarch64 platform specific code.
+#[cfg(all(target_arch = "aarch64"))]
+#[path = "arch/aarch64/mod.rs"]
+pub mod arch;
+
 mod pages;
 mod sc;
 mod zone;
 
+pub use arch::*;
 pub use pages::*;
 pub use sc::*;
 pub use zone::*;
@@ -47,19 +58,6 @@ use core::mem;
 use core::ptr::{self, NonNull};
 
 use log::trace;
-
-#[cfg(target_arch = "x86_64")]
-const CACHE_LINE_SIZE: usize = 64;
-
-#[cfg(target_arch = "x86_64")]
-const BASE_PAGE_SIZE: usize = 4096;
-
-#[cfg(target_arch = "x86_64")]
-#[allow(unused)]
-const LARGE_PAGE_SIZE: usize = 2 * 1024 * 1024;
-
-#[cfg(target_arch = "x86_64")]
-type VAddr = usize;
 
 /// Error that can be returned for `allocation` and `deallocation` requests.
 #[derive(Debug)]


### PR DESCRIPTION
Not all architectures have the same page sizes or cacheline sizes.
This commit adds architecture specific features that enable the
selection of differenet page and cacheline sizes. One prominent example
is aarch64 that supports three different granules and thus has features
to select the page size for the relevant granule.
