### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ log = "0.4"
 [target.'cfg(unix)'.dev-dependencies]
 rand = "0.8"
 env_logger = "0.9"
-spin = "0.9.0"
+spin = "0.9.8"


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)