### PR TITLE
Remove const_mut_refs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
 //! # Implementing GlobalAlloc
 //! See the [global alloc](https://github.com/gz/rust-slabmalloc/tree/master/examples/global_alloc.rs) example.
 #![allow(unused_features)]
-#![cfg_attr(feature = "unstable", feature(const_mut_refs))]
 #![cfg_attr(test, feature(prelude_import, test, c_void_variant, core_intrinsics))]
 #![no_std]
 #![crate_name = "slabmalloc"]


### PR DESCRIPTION
Feature `const_mut_refs` has become stable since [Rust 1.83.0](https://github.com/rust-lang/rust/blob/827a0d638dabc9a22c56f9c37a557568f86ac76c/src/tools/clippy/clippy_utils/src/msrvs.rs#L23) so we don't need to enable it explicitly.